### PR TITLE
change tracking_status type from object to string

### DIFF
--- a/tap_shippo/schemas/transactions.json
+++ b/tap_shippo/schemas/transactions.json
@@ -31,7 +31,7 @@
             "type": "string"
         },
         "tracking_status": {
-            "type": ["null", "object"]
+            "type": ["null", "string"]
         },
         "tracking_history": {
             "type": "array"


### PR DESCRIPTION
In [Version 2017-03-29](https://goshippo.com/docs/reference?version=2017-03-29#transactions) of the Shippo API, the `tracking_status` from the `transactions` endpoint is labeled as a `dict` (i.e. an object). Since [Version 2017-08-01](https://goshippo.com/docs/reference?version=2017-08-01#transactions), `tracking_status` has been changed to be a string. To account for this, the schema has been updated.