### PR TITLE
Specify the API version of the tap schema

### DIFF
--- a/tap_shippo/__init__.py
+++ b/tap_shippo/__init__.py
@@ -90,6 +90,8 @@ def request(url):
 
     '''
     headers = {'Authorization': 'ShippoToken ' + CONFIG['token']}
+    headers['Shippo-API-Version'] = '2018-02-08'
+    
     if 'user_agent' in CONFIG:
         headers['User-Agent'] = CONFIG['user_agent']
 


### PR DESCRIPTION
Since the schema has changed between versions, tell the API how the schema is configured.