### PR TITLE
[PLACEHOLDER] Update singer-python version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-shippo',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_shippo'],
       install_requires=[
-          'singer-python==1.6.0',
+          'singer-python==5.9.1',
           'backoff==1.3.2',
           'requests==2.20.0',
       ],
@@ -30,4 +30,3 @@ setup(name='tap-shippo',
       },
       include_package_data=True,
 )
-


### PR DESCRIPTION
# Description of change
This PR is intended to accompany the changes in https://github.com/singer-io/singer-python/pull/126. In short, Airflow 10.7 is dependent on `jsonschema >= 3.0.0`, and `singer-python` depends on `jsonschema==2.6.0`. However, as the version has not been updated yet, this PR stands to reduce later contribution efforts.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
