### PR TITLE
Fix issue where Shippo may return an unsecure URL in NEXT field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-shippo',
-      version='0.7.3',
+      version='0.7.4',
       description='Singer.io tap for extracting data from the Shippo API',
       author='Robert J. Moore',
       url='http://singer.io',

--- a/tap_shippo/__init__.py
+++ b/tap_shippo/__init__.py
@@ -74,6 +74,10 @@ def client_error(exc):
 
 
 def parse_stream_from_url(url):
+    '''Ensure URL uses https, Shippo sometimes provides http urls in the NEXT field which raises ValueError'''
+    if isinstance(url, str):
+        url = url.replace("http://", "https://")
+
     '''Given a Shippo URL, extract the stream name (e.g. "addresses")'''
     match = re.match(URL_PATTERN, url)
     if not match:


### PR DESCRIPTION
# Description of change
Yesterday when trying to use this Tap I encounter an issue. After reviewing [the log](https://gist.github.com/brentmulligan/e2f62a2bc16847545db5a174a70ab437) and code I determined that Shippo was providing insecure http URLs in the results 'next' field. Since this Tap checks the next URL against a regex pattern that expects a secure URL this was leading to a fatal error ("Can't determine stream from URL").

To correct the issue I simply check to ensure we have a string for URL and then string replace http:// with https://.

# Manual QA steps
 - Add config.json & state.json
 - tap-shippo -c config.json -s state.json
 
# Risks
- I almost never use Python so maybe there is a better way to do this. 

# Rollback steps
 - revert this branch
